### PR TITLE
[최보근] table 마크다운 설정, 마크다운 컴포넌트 파일 분리

### DIFF
--- a/src/components/main/ChatLogs.js
+++ b/src/components/main/ChatLogs.js
@@ -1,5 +1,5 @@
-import { useSelector } from 'react-redux';
-import TypingAnimation from './TypingAnimation';
+import { useSelector } from "react-redux";
+import TypingAnimation from "./TypingAnimation";
 
 // 채팅 log 컴포넌트
 function ChatLogs() {
@@ -15,9 +15,9 @@ function ChatLogs() {
           <li
             key={index}
             className={`p-3 m-5 rounded-md max-w-2/3 max-h-200 overflow-hidden ${
-              message.user === 'user'
-                ? 'bg-blue-200 ml-auto mr-0'
-                : 'bg-gray-200 ml-0'
+              message.user === "user"
+                ? "bg-blue-200 ml-auto mr-0"
+                : "bg-gray-200 ml-0"
             }`}
           >
             {<TypingAnimation text={message.message} />}
@@ -25,7 +25,7 @@ function ChatLogs() {
         ))}
         {loading && (
           <li className="p-3 m-5 rounded-md max-w-2/3 overflow-hidden bg-gray-200 ml-0">
-            {<TypingAnimation text={'메시지를 생성 중입니다...'} />}
+            {<TypingAnimation text={"메시지를 생성 중입니다..."} />}
           </li>
         )}
       </ul>

--- a/src/components/main/MarkdownComponents.js
+++ b/src/components/main/MarkdownComponents.js
@@ -1,0 +1,70 @@
+import React from "react";
+
+// Custom CodeBlock 컴포넌트
+export const CodeBlock = ({ inline, className, children }) => {
+  const match = /language-(\w+)/.exec(className || "");
+  const style =
+    !inline && match
+      ? {
+          border: "0.5px solid #ddd",
+          padding: "2px",
+          borderRadius: "5px",
+          background: "#333", // 어두운 배경색으로 변경
+          color: "#fff", // 글자색을 흰색으로 변경
+          overflowX: "scroll",
+        }
+      : {
+          border: "0.5px solid #ddd",
+          padding: "2px",
+          borderRadius: "5px",
+          background: "#333", // 어두운 배경색으로 변경
+          color: "#fff", // 글자색을 흰색으로 변경
+          overflowX: "scroll",
+          marginBottom: "-4px",
+          display: "inline-block",
+        };
+
+  return (
+    <div style={style}>
+      <pre>
+        <code>{children}</code>
+      </pre>
+    </div>
+  );
+};
+
+// Custom Table 컴포넌트
+export const TableComponent = ({ children }) => {
+  return (
+    <div className="table-auto">
+      <table className="min-w-full divide-y divide-gray-200">{children}</table>
+    </div>
+  );
+};
+
+export const TableRowComponent = ({ children }) => {
+  return React.createElement(
+    "tr",
+    {
+      className: "bg-gray-100",
+    },
+    children
+  );
+};
+
+export const TableCellComponent = ({ node, children }) => {
+  const { tagName } = node;
+
+  const isHeader = tagName === "th";
+  const align = node.align || (node.properties && node.properties.align);
+
+  const cellType = isHeader ? "th" : "td";
+
+  return React.createElement(
+    cellType,
+    {
+      className: `py-2 px-4 border ${align ? `text-${align}` : ""}`,
+    },
+    children
+  );
+};

--- a/src/components/main/TypingAnimation.js
+++ b/src/components/main/TypingAnimation.js
@@ -1,60 +1,19 @@
 import React, { useState, useEffect } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import {
+  CodeBlock,
+  TableCellComponent,
+  TableComponent,
+  TableRowComponent,
+} from "./MarkdownComponents";
 
-// Custom CodeBlock 컴포넌트
-const CodeBlock = ({ inline, className, children }) => {
-  const match = /language-(\w+)/.exec(className || '');
-  const style = !inline && match ? {
-    border: "0.5px solid #ddd",
-    padding: "2px",
-    borderRadius: "5px",
-    background: "#333", // 어두운 배경색으로 변경
-    color: "#fff", // 글자색을 흰색으로 변경
-    overflowX: "scroll",
-  } : {
-    border: "0.5px solid #ddd",
-    padding: "2px",
-    borderRadius: "5px",
-    background: "#333", // 어두운 배경색으로 변경
-    color: "#fff", // 글자색을 흰색으로 변경
-    overflowX: "scroll",
-    marginBottom: "-4px",
-    display: "inline-block",
-  };
-
-  return (
-    <div 
-    style={style}
-    >
-      <pre>
-        <code>{children}</code>
-      </pre>
-    </div>
-  );
-};
-const TableBlock = ({ children }) => {
-
-  /**
-   * TODO: 테이블 블록을 위한 마크다운 만들기 (타 소스 적극 활용 가능)
-   */ 
-  const style = {
-    border: "0.5px solid #ddd",
-    padding: "2px",
-    borderRadius: "5px",
-    background: "#333", // 어두운 배경색으로 변경
-    color: "#fff", // 글자색을 흰색으로 변경
-    overflowX: "scroll",
-  };
-
-  return (
-    <div 
-    style={style}
-    >
-      {children}
-      
-    </div>
-  );
+const components = {
+  code: CodeBlock,
+  table: TableComponent,
+  tr: TableRowComponent,
+  td: TableCellComponent,
+  th: TableCellComponent,
 };
 
 function TypingAnimation({ text }) {
@@ -82,8 +41,8 @@ function TypingAnimation({ text }) {
   }, [text]);
 
   return (
-    <div className="overflow-x-scroll">
-      <ReactMarkdown components={{ code: CodeBlock, table: TableBlock }} remarkPlugins={[remarkGfm]}>
+    <div className="overflow-x-auto">
+      <ReactMarkdown components={components} remarkPlugins={[remarkGfm]}>
         {visibleText}
       </ReactMarkdown>
     </div>


### PR DESCRIPTION
table마크다운 설정했습니다.

그런데 text-right만 적용이 안되는 상황입니다.

| Left-aligned | Center-aligned | Right-aligned |
| :---         | :---:          | ---:          |
| This         | This           | This          |
| column       | column         | column        |
| will         | will           | will          |
| be           | be             | be            |
| left         | center         | right         |
| aligned      | aligned        | aligned       |

"---:" 부분을 찾아서
\<td className=" ... text-right"\> 까지 되는걸 확인했는데도 이러네요

추가로, 마크다운 컴포넌트들이 좀 많아져서 따로 js 파일 분리했습니다.

일단 PR 날림