### PR TITLE
fix: 최소화 아이콘 적용, 업로드 완료 박스 유지시간 변경

### DIFF
--- a/src/components/left-side/PrintFileCards.js
+++ b/src/components/left-side/PrintFileCards.js
@@ -3,7 +3,7 @@ import { useSelector, useDispatch } from "react-redux";
 import Download from "../Utility/Download";
 import { Closeicon } from "../../icons";
 
-function PrintFileCards({ processAll = true }) {
+function PrintFileCards({ processAll = false }) {
   // 이 컴포넌트에서 사용할 data 변수
   const analyzedFileDataList = useSelector(
     (state) => state.dataVar.analyzedFileDataList
@@ -41,7 +41,7 @@ function PrintFileCards({ processAll = true }) {
       {dataListToProcess.map((analyzedFileData, index) => (
         <div
           key={index}
-          className={`max-w-full p-3 border border-gray-200 rounded-lg shadow cursor-pointer mb-3 ${
+          className={`max-w-full p-3 border border-gray-200 rounded-lg shadow cursor-pointer ${
             clickedIndex === index ? "bg-blue-500 text-white" : "bg-white"
           } break-words flex flex-col `}
           onClick={() => handleCardClick(index)}

--- a/src/components/main/Input/FileInputButton.js
+++ b/src/components/main/Input/FileInputButton.js
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { setFileData } from "../../../reducers/dataReducers";
 import { updateAppState } from "../../../reducers/appStateReducer";
 import PrintFileCards from "../../left-side/PrintFileCards";
-import { Bellicon, Closeicon, Exclamicon, Fileicon } from "../../../icons";
+import { Bellicon, Exclamicon, Fileicon, Minimizeicon } from "../../../icons";
 import FileUploadToServer from "./FileUploadToServer";
 import Loader from "../Chat/Loader";
 
@@ -51,7 +51,7 @@ function FileInput() {
     if (currentState === "analyzed" || currentState === "analyzed error") {
       const timer = setTimeout(() => {
         setShowAlert(false);
-      }, 1000);
+      }, 3000);
 
       return () => clearTimeout(timer);
     }
@@ -112,7 +112,7 @@ function FileInput() {
           onClick={() => setIsPrintFileCards(false)}
           className="cursor-pointer text-gray-500 hover:text-gray-700"
         >
-          <Closeicon />
+          <Minimizeicon />
         </span>
         <PrintFileCards />
       </div>

--- a/src/icons.js
+++ b/src/icons.js
@@ -12,6 +12,7 @@ import {
   faChevronLeft,
   faXmark,
   faFile,
+  faSquareMinus,
 } from "@fortawesome/free-solid-svg-icons";
 
 import { faPaperPlane, faBell } from "@fortawesome/free-regular-svg-icons";
@@ -93,4 +94,8 @@ export function Closeicon() {
 
 export function Fileicon() {
   return <FontAwesomeIcon icon={faFile} size="xl" />;
+}
+
+export function Minimizeicon() {
+  return <FontAwesomeIcon icon={faSquareMinus} size="xl" />;
 }


### PR DESCRIPTION
## 변경점
1. 첨부파일 박스 최소화 아이콘 적용
    - X(faXmark) 에서 \[ - \](faSquareMinus) 로 변경
2. 첨부파일 박스가 최근 1건의 데이터만 다루도록 변경
    - 대응하여 margin-bottom도 자연스럽게 변경
4. 업로드 완료 창 유지시간 1초 -> 3초 변경