### PR TITLE
[최보근] 문제 해결 (파일 업로드 이후 파일 분석 완료 창이 재생성되는 문제)

### DIFF
--- a/src/components/main/Input/FileInputButton.js
+++ b/src/components/main/Input/FileInputButton.js
@@ -47,10 +47,11 @@ function FileInput() {
       setShowAlert(true);
     }
 
-    // analyzed or analyzed error 상태일 때 1초 후 알림창을 숨김
+    // analyzed or analyzed error 상태일 때 3초 후 알림창을 숨김
     if (currentState === "analyzed" || currentState === "analyzed error") {
       const timer = setTimeout(() => {
         setShowAlert(false);
+        dispatch(updateAppState("message_waiting"));
       }, 3000);
 
       return () => clearTimeout(timer);


### PR DESCRIPTION
문제 해결.

알림창이 뜨는 useEffect에서,

timer 부분에서 3초가 지나면

setAlert(false); 와 함께

state도 같이 변경하도록 수정.