### PR TITLE
RecapViewer 디자인 개선

### DIFF
--- a/src/components/Data/RecapViewer.js
+++ b/src/components/Data/RecapViewer.js
@@ -18,13 +18,23 @@ function RecapViewer() {
     }
   }, [recap]);
   return (
-    <div>
-      <h1 className="text-2xl font-bold text-gray-900 mb-2">{title}</h1>
-      <h3 className="text-xl font-semibold text-gray-700 mb-4">{subtitle}</h3>
+    <div className="p-4">
+      <h1 className="text-2xl font-bold text-center text-gray-900 mb-2">
+        {title}
+      </h1>
+      <h3 className="text-xl font-semibold text-center text-gray-700 mb-4">
+        {subtitle}
+      </h3>
       <p className="text-gray-600 mb-4">{summary}</p>
       <div>
-        <strong className="font-semibold text-gray-900">Keywords: </strong>
-        <span className="text-gray-600">{keywords.join(", ")}</span>
+        {keywords.map((keyword, index) => (
+          <span
+            key={index}
+            className="inline-block bg-gray-200 rounded-full px-3 py-1 text-sm font-semibold text-gray-700 mr-2 mb-2"
+          >
+            {keyword}
+          </span>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
RecapViewer 디자인 개선했습니다. 
- AS-IS
(평문 형태)

- TO-BE
<img width="878" alt="image" src="https://github.com/inha-carbon-neutral-seven/beaver-web-client/assets/100016044/a9fa6d8b-65bf-4e9e-8280-83f7bae6c282">
