### PR TITLE
[서강문] 채팅 소스 overflow 조정

### DIFF
--- a/src/components/main/Chat/MessageSource.js
+++ b/src/components/main/Chat/MessageSource.js
@@ -4,14 +4,20 @@ function MessageSource({ message }) {
       <div className="bg-gray-50/50 w-auto h-6 pl-1 my-2 font-bold">Source</div>
       {message.input && (
         <div className="border m-1 rounded">
-          <div className="bg-gray-50/50 pl-1 my-2 text-green-600">input</div>
-          <pre className="pl-4">{message.input}</pre>
+          <div className="bg-gray-50/50 pl-1 my-2 text-green-600">Input</div>
+          <div className="p-1">
+            <pre className="overflow-x-auto text-xs">{message.input}</pre>
+          </div>
         </div>
       )}
       {message.output && (
         <div className="border m-1 rounded">
-          <div className="bg-gray-50/50 pl-1 my-2 text-blue-600">output</div>
-          <pre className="pl-4">{message.output}</pre>
+          <div className="bg-gray-50/50 pl-1 my-2 text-blue-600">
+            {message.input ? "Output" : "Document"}
+          </div>
+          <div className="p-1">
+            <pre className="overflow-x-auto text-xs">{message.output}</pre>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
채팅 소스 overflow-x로 깨지는 현상 완화했습니다. 

아직도 소스가 너무 많으면 조금은 깨질텐데, 소스 스타일이 깨지는 원인은 **pre 쪽에 붙은 padding, margin** 때문이에요

```html
          <div className="p-1"> <!-- 옆에 이 녀석 -->
            <pre className="overflow-x-auto text-xs">{message.output}</pre>
          </div>
```

삭제하거나, 현명한 방법으로 패딩을 주면 완화될 것으로 예상됩니다잉