### PR TITLE
[서강문] UI 깎기, 시연 때 보여줄 내용 최소치로 깎았음

### DIFF
--- a/src/components/Data/DOCViewer.js
+++ b/src/components/Data/DOCViewer.js
@@ -27,11 +27,19 @@ const DOCViewer = () => {
       </div>
     );
   }
-  const documentConfig = { uri: fileURL, fileType: fileType };
+
+  const documentConfig = {
+    uri: fileURL,
+    fileName: `${file.name.slice(0, Math.min(file.name.length, 50))} ...`,
+    fileType: fileType,
+  };
 
   return (
-    <div className="bg-[rgb(232,240,240)]">
-      <DocViewer pluginRenderers={DocViewerRenderers} documents={[documentConfig]} />;
+    <div className="bg-white rounded-md p-2">
+      <DocViewer
+        pluginRenderers={DocViewerRenderers}
+        documents={[documentConfig]}
+      />
     </div>
   );
 };

--- a/src/components/Data/DashSidebar.js
+++ b/src/components/Data/DashSidebar.js
@@ -40,29 +40,32 @@ function DashSidebar() {
   return (
     <div className="flex flex-col justify-center items-center w-full h-full ">
       {currentChart ? (
-        <div className="w-full">
-          <div className="button-container flex justify-center mb-4 font-bold text-3xl">
-            <button onClick={prevChart} className="mx-2">
-              ← |
+        <div className="w-full rounded-md bg-white">
+          <div className="pt-5 button-container flex justify-center mb-4 font-bold text-2xl">
+            <button onClick={prevChart} className="mx-2 text-xs">
+              ◄
             </button>
             <div className="mx-2">
-              {selectedChartIndex + 1 + " / " + ChartsfromStore.length}
+              {`${1 + selectedChartIndex} of ${ChartsfromStore.length} `}
             </div>
-            <button onClick={nextChart} className="mx-2">
-              | →
+            <button onClick={nextChart} className="mx-2 text-xs">
+              ►
             </button>
           </div>
-          <div className="chart-container p-10 w-full dark:bg-[rgb(232,240,240)]">
+          <div className="chart-container p-2 w-full dark:bg-[rgb(232,240,240)]">
             <ChartComponent chartData={currentChart} />
           </div>
         </div>
       ) : (
         <div className=" text-center">
           <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-4">
-            분석할 파일이 존재하지 않습니다 :(
+            비버 대시보드
           </h1>
+          <p className="text-lg text-gray-600 dark:text-gray-400">
+            파일을 먼저 업로드해주세요.
+          </p>
           <p className="text-lg text-gray-600 dark:text-gray-400 mb-6">
-            분석할 파일을 업로드해주세요.
+            유용한 정보를 제공해드려요 !
           </p>
         </div>
       )}

--- a/src/components/Data/RecapViewer.js
+++ b/src/components/Data/RecapViewer.js
@@ -20,20 +20,27 @@ function RecapViewer() {
     }
   }, [recap]);
   return (
-    <div className="p-4 h-full flex-row text-[rgb()] dark:text-[rgb(232,240,240)]">
-      <h1 className="text-2xl font-bold text-center text-gray-900 mb-2">{title}</h1>
-      <h3 className="text-xl font-semibold text-center">{subtitle}</h3>
-      <div className="text-gray-600 mb-4">
-        {summary.split("\n").map((line, index) => (
-          <p key={index}>{line}</p>
-        ))}
-      </div>{" "}
-      <div>
-        {keywords.map((keyword, index) => (
-          <span key={index} className="inline-block bg-gray-200 rounded-full px-3 py-1 text-sm font-semibold text-gray-700 mr-2 mb-2">
-            {keyword}
-          </span>
-        ))}
+    <div className="p-4 h-full flex-row text-[rgb()] dark:text-[rgb(232,240,240)] horizon">
+      <div className="bg-white rounded-md p-3">
+        <h1 className="text-2xl font-bold text-center text-gray-900 mb-2">
+          {title}
+        </h1>
+        <h3 className="text-xl font-semibold text-center">{subtitle}</h3>
+        <div className="text-gray-600 mb-4">
+          {summary.split("\n").map((line, index) => (
+            <p key={index}>{line}</p>
+          ))}
+        </div>{" "}
+        <div>
+          {keywords.map((keyword, index) => (
+            <span
+              key={index}
+              className="inline-block bg-gray-200 rounded-full px-3 py-1 text-sm font-semibold text-gray-700 mr-2 mb-2"
+            >
+              {keyword}
+            </span>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/src/components/main/Chat/InitialGuide.js
+++ b/src/components/main/Chat/InitialGuide.js
@@ -63,10 +63,10 @@ function InitialGuide() {
         </p>
         <div className="h-[30px]"></div>
         <p className="text-lg font-bold text-center text-[rgb(66,66,66)] dark:text-[rgb(230,230,230)]">
-          비버는 일반적인 챗봇🤖 기능을 제공하며, 파일을 첨부하면 파일 종류에 따라 질문응답이 가능합니다.
+          비버.ai는 소매업 파일을 첨부하면 맞춤형 정보를 제공해드려요.
         </p>
         <p className="text-lg font-bold text-center text-[rgb(66,66,66)] dark:text-[rgb(230,230,230)]">
-          비버를 통해 문서 파일에 대한 질문응답과 데이터 시각화, 분석을 통한 풍부한 정보를 얻어보세요!
+          쉽고 간단하게 데이터를 분석하면서 유용한 통찰을 얻어보세요.
         </p>
       </div>
 

--- a/src/components/right-side/RightSidebar.js
+++ b/src/components/right-side/RightSidebar.js
@@ -128,8 +128,7 @@ function RightSidebar() {
         className={`max-w-64 h-[100vh] backdrop-blur-xl space-y-2 
         flex-shrink-0 drop-shadow-lg overflow-hidden
          transform transition-all duration-100 ease-in-out 
-         flex flex-col justify-center items-center dark:bg-[rgb(30,30,35)]
-          bg-[rgb(204,153,146)] shadow-md rounded-l-lg`}
+         flex flex-col justify-center items-center bg-[rgba(217,148,132,0.3)] dark:bg-[rgba(45,47,51,0.3)] shadow-md rounded-l-lg`}
         style={{ width: width, transition: "width 500ms ease-in-out" }}
       >
         {width > 0 && <div className=" px-1 w-full h-full overflow-auto">{renderContent()}</div>}
@@ -137,7 +136,7 @@ function RightSidebar() {
 
       <aside
         className={`flex-initial h-full w-[45px] backdrop-blur-xl 
-      bg-[rgb(191,115,115)] dark:bg-[rgb(20,20,20)] drop-shadow-lg 
+        bg-[rgb(217,148,132)] dark:bg-[rgb(45,47,51)] drop-shadow-lg 
       overflow-hidden flex flex-col justify-between`}
       >
         <div className="flex flex-col items-center text-[rgb(232,240,240)] dark:text-[rgb(115,114,111)]">

--- a/src/components/top-side/Header.js
+++ b/src/components/top-side/Header.js
@@ -3,7 +3,7 @@ import beaver from "../../image/logo.jpg";
 
 function Header() {
   return (
-    <div className="z-50 h-16 bg-[rgb(217,148,132)] dark:bg-[rgb(45,47,51)] justify-between flex items-center w-full rounded-[12px] drop-shadow-lg mt-3">
+    <div className="z-50 h-16 bg-[rgb(217,148,132)] dark:bg-[rgb(45,47,51)] justify-between flex items-center w-full rounded-[12px] drop-shadow-lg">
       <div className="flex items-center space-x-4">
         <a href="/" className="flex items-center">
           <img src={beaver} className="h-12 mx-3 rounded-full" />


### PR DESCRIPTION
## 채팅 UI
- 마진 안 맞던거 조금 수정
- 지금도 문제 있음. 배율 (100%+-) 에 따라 채팅 쪽 UI 상하단이 안맞아요

## initial guide
- 문구 수정

## 대시보드 공통
- 붉은 기 있는 색상에서 beaver-brown으로 통일
- 대시보드 상세내역은 투명도 설정
- 문구 수정

## 원본 대시보드
- 타이틀 이상한 해시에서 이름으로 바꿈
- 이름으로 바꾸는 김에 60byte 이상이면 '...' 되도록 기능도 넣음

## 차트 대시보드 
- 페이징 디자인 바꿈
- 좀 더 근본있는 방식으로? 